### PR TITLE
The dialog boxes no longer throws an error when fields not filled in

### DIFF
--- a/src/kps/gui/FormDialog.java
+++ b/src/kps/gui/FormDialog.java
@@ -179,6 +179,16 @@ public abstract class FormDialog extends JDialog {
         return values;
     }
 
+    protected boolean fieldsValid(){
+        for(Map.Entry<Object, Gettable<Object>> c : valueMap.entrySet()) {
+            if (c.getValue().getValue() == null || c.getValue().getValue().toString().length() == 0) {
+                JOptionPane.showMessageDialog(this, "Sorry one or more fields was invalid. Please fill in all of the fields and try again.", "Invalid input", JOptionPane.WARNING_MESSAGE);
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected abstract JComponent[][] getAllFields();
     protected abstract void save();
     protected abstract boolean cancel();

--- a/src/kps/gui/windows/MailDialog.java
+++ b/src/kps/gui/windows/MailDialog.java
@@ -54,6 +54,7 @@ public class MailDialog extends FormDialog {
     }
 
     protected void save() {
+        if (!fieldsValid()) return;
         Set<Map.Entry<Object, Object>> entries = getAllValues().entrySet();
         for(Map.Entry<Object, Object> entry : entries) {
             switch((FieldNames)entry.getKey()) {

--- a/src/kps/gui/windows/RouteDialog.java
+++ b/src/kps/gui/windows/RouteDialog.java
@@ -75,6 +75,7 @@ public class RouteDialog extends FormDialog {
     }
 
     protected void save() {
+        if (!fieldsValid()) return;
         Set<Map.Entry<Object, Object>> entries = getAllValues().entrySet();
         for(Map.Entry<Object, Object> entry : entries) {
             switch((FieldNames)entry.getKey()) {


### PR DESCRIPTION
The dialog boxes no longer throws an error if not all of the fields are filled in. Instead, the program displays a message asking the user to fill in all fields.
